### PR TITLE
percent sign fix

### DIFF
--- a/bin/figlet
+++ b/bin/figlet
@@ -52,5 +52,6 @@ figlet(text, options, function(err, data) {
         console.dir(err);
         return;
     }
+    data = data.replace(/%/g, '%%');
     console.log(data);
 });


### PR DESCRIPTION
Hi! I noticed console.log prints out one percent sign if it finds two, so my fix is to replace all percent signs with double percent signs to ensure correct output (needed for eg. "AMC AAA01").
