### PR TITLE
Fontfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ figlet -f "Dancing Font" "Hi"
 Following example uses an external font file
 
 ```shell
-figlet -ff .\phm-largetype.flf "Hi"
+figlet --ff .\phm-largetype.flf "Hi"
 ```
 
 ## Goals

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Below is an example that uses a custom font.
 figlet -f "Dancing Font" "Hi"
 ```
 
+Following example uses an external font file
+
+```shell
+figlet -ff .\phm-largetype.flf "Hi"
+```
+
 ## Goals
 
 Eventually I think it would be nice for this app to have to same command line interface as the C-based app.

--- a/bin/figlet
+++ b/bin/figlet
@@ -13,6 +13,8 @@ var figlet = require('figlet'),
     .describe('l', 'List all the available fonts')
     .alias('f', 'font')
     .describe('f', 'A string value that indicates the FIGlet font to use')
+    .alias('ff', 'fontfile')
+    .describe('ff', 'A string value that specifies the FIGlet font file to use')
     .describe('horizontal-layout', 'A string value that indicates the horizontal layout to use')
     .describe('vertical-layout', 'A string value that indicates the vertical layout to use');
 
@@ -42,7 +44,17 @@ if (!text || argv.help) {
     return console.log(optimist.help());
 }
 
+if (argv.font && argv.fontfile) {
+    return console.log('The options --font and --fontfile are mutually exclusive');
+}
+
 if (argv.font) options.font = argv.font
+if (argv.fontfile) {
+    const fs = require('fs');
+    const data = fs.readFileSync(argv.fontfile, 'utf8');
+    figlet.parseFont('customfont', data);
+    options.font = 'customfont';
+}
 if (argv['horizontal-layout']) options.horizontalLayout = argv['horizontal-layout']
 if (argv['vertical-layout']) options.verticalLayout = argv['vertical-layout']
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "figlet-cli",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Command line interface for the FIGlet.js library.",
     "keywords": ["figlet", "ascii", "art", "banner", "ansi"],
     "repository": {
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "optimist": "~0.6.0",
-        "figlet": "^1.3.0"
+        "figlet": "^1.8.0"
     },
     "devDependencies": {
         "grunt-contrib-jshint": "~0.6.0",


### PR DESCRIPTION
The PR adds the option `-ff` to specify an external font file.

![image](https://github.com/user-attachments/assets/00a613bb-9748-4bdb-913f-10613ace2f65)


Additionally it updates figlet.js to 1.8