### PR TITLE
Improve command-line. Add support for fonts over the web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bin/figlet
+++ b/bin/figlet
@@ -11,6 +11,8 @@ var figlet = require('figlet'),
     .alias('v', 'version')
     .alias('l', 'list')
     .describe('l', 'List all the available fonts')
+    .alias('e', 'examples')
+    .describe('e', 'Print an example in all available fonts')
     .alias('f', 'font')
     .describe('f', 'A string value that indicates the FIGlet font to use')
     .alias('ff', 'fontfile')
@@ -35,6 +37,28 @@ if (argv.list) {
         }
         fonts.forEach(function(font) {
             console.log(font);
+        });
+    });
+    return;
+}
+
+if (argv.examples) {
+    figlet.fonts(function(err, fonts) {
+        if (err) {
+          console.log('something went wrong...');
+          console.dir(err);
+          return;
+        }
+        fonts.forEach(function(font) {
+            figlet(font, { font: font }, function(err, data) {
+                if (err) {
+                    console.log('something went wrong...');
+                    console.dir(err);
+                    return;
+                }
+                data = data.replace(/%/g, '%%');
+                console.log(data);
+            });
         });
     });
     return;

--- a/bin/figlet
+++ b/bin/figlet
@@ -28,7 +28,7 @@ var figlet = require('figlet'),
     .alias('f', 'font')
     .describe('f', 'A string value that indicates the FIGlet font to use')
     .alias('ff', 'fontfile')
-    .describe('ff', 'A string value that specifies the FIGlet font file to use')
+    .describe('ff', 'A string value that specifies the FIGlet font file to use. Can be local or URL')
     .describe('horizontal-layout', 'A string value that indicates the horizontal layout to use')
     .describe('vertical-layout', 'A string value that indicates the vertical layout to use');
 
@@ -85,21 +85,67 @@ if (argv.font && argv.fontfile) {
 }
 
 if (argv.font) options.font = argv.font
-if (argv.fontfile) {
-    const fs = require('fs');
-    const data = fs.readFileSync(argv.fontfile, 'utf8');
-    figlet.parseFont('customfont', data);
-    options.font = 'customfont';
-}
-if (argv['horizontal-layout']) options.horizontalLayout = argv['horizontal-layout']
-if (argv['vertical-layout']) options.verticalLayout = argv['vertical-layout']
 
-figlet(text, options, function(err, data) {
-    if (err) {
-        console.log('Something went wrong...');
-        console.dir(err);
-        return;
+new Promise(function(resolve, reject) {
+    if (argv.fontfile) {
+        console.log("DEBUG")
+        const url = require('url');
+        try {
+            const location = new url.URL(argv.fontfile);
+            switch(location.protocol) {
+                case 'http:':
+                case 'https:':
+                    const https = require('https');
+                    https.get(location, (res) => {
+                        let data = '';
+                        res.on('data', (chunk) => {
+                            data += chunk;
+                        });
+                        res.on('end', () => {
+                            figlet.parseFont('customfont', data);
+                            options.font = 'customfont';
+                            resolve();
+                        });
+                        res.on('error', reject);
+                    });
+                    break;
+                case 'file:':
+                    const fs = require('fs');
+                    fs.readFile(location, 'utf8', (err, data) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            figlet.parseFont('customfont', data);
+                            options.font = 'customfont';
+                            resolve();
+                        }
+                    });
+                    break;
+                default:
+                    reject(new Error(`Unsupported protocol: ${location.protocol}`));
+                    break;
+            }
+        } catch (e) {
+            reject(e);
+        }
+    } else {
+        resolve();
     }
-    data = data.replace(/%/g, '%%');
-    console.log(data);
+}).then(function() {
+    if (argv['horizontal-layout']) options.horizontalLayout = argv['horizontal-layout']
+    if (argv['vertical-layout']) options.verticalLayout = argv['vertical-layout']
+    
+    figlet(text, options, function(err, data) {
+        if (err) {
+            console.log('Something went wrong...');
+            console.dir(err);
+            return;
+        }
+        data = data.replace(/%/g, '%%');
+        console.log(data);
+    });
+}).catch(function(err) {
+    console.log('Something went wrong...');
+    console.dir(err);
+    return;
 });

--- a/bin/figlet
+++ b/bin/figlet
@@ -4,9 +4,21 @@
 
 process.title = 'figlet';
 
+const usage = (() => {
+    let path = require('path');
+
+    let location = require.resolve("figlet");
+    location = path.join(location, "..", "/../fonts/");
+    
+    return [
+        'Usage: $0 "text to print"',
+        `Fonts: ${location}`,
+    ].join('\n\n');
+})();
+
 var figlet = require('figlet'),
     optimist = require('optimist')
-    .usage('Usage: $0 "text to print"')
+    .usage(usage)
     .alias('h', 'help')
     .alias('v', 'version')
     .alias('l', 'list')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "figlet-cli",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Command line interface for the FIGlet.js library.",
     "keywords": ["figlet", "ascii", "art", "banner", "ansi"],
     "repository": {


### PR DESCRIPTION
### Proposed Changes:
## Major:
- add `-e`/`-examples` command line flag
  - prints the name of each font in that font
- add support for `http`, `https`, and `file` URIs for `-ff`
### Minor:
- add font directory to help/usage text
### Patch:
- promisify font loading (in support of web fonts)
- add gitignore